### PR TITLE
Move Detekt configuration to Gradle Plugin (#179)

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(libs.kotlin.gradle.plugin)
     implementation(libs.ksp.gradle.plugin)
     implementation(libs.android.gradle.plugin)
+    implementation(libs.detekt.gradle.plugin)
     implementation(gradleApi())
     implementation(gradleKotlinDsl())
 }
@@ -60,5 +61,11 @@ gradlePlugin {
         displayName = "Kotlin Symbol Processing Support Plugin"
         description = "The Gradle Plugin that adds KSP support to the module"
         implementationClass = "mpeix.plugins.support.KspSupportPlugin"
+    }
+    plugins.create("mpeixDetektPlugin") {
+        id = "mpeix.detekt"
+        displayName = "Detekt configuration Plugin"
+        description = "The Gradle Plugin that configures Detekt in subproject"
+        implementationClass = "mpeix.plugins.support.DetektPlugin"
     }
 }

--- a/build-logic/gradle/libs.versions.toml
+++ b/build-logic/gradle/libs.versions.toml
@@ -2,11 +2,13 @@
 kotlin = "1.8.21"
 ksp = "1.8.21-1.0.11"
 agp = "8.0.0"
+detekt = "1.22.0"
 
 [libraries]
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 ksp-gradle-plugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/build-logic/src/main/kotlin/mpeix/plugins/convention/BaseAndroidConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/mpeix/plugins/convention/BaseAndroidConventionPlugin.kt
@@ -25,6 +25,7 @@ internal class BaseAndroidConventionPlugin : Plugin<Project> {
                 apply("kotlin-android")
                 apply("kotlin-parcelize")
                 apply("org.gradle.android.cache-fix")
+                apply("mpeix.detekt")
             }
 
             val libs = versionCatalog

--- a/build-logic/src/main/kotlin/mpeix/plugins/convention/KotlinConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/mpeix/plugins/convention/KotlinConventionPlugin.kt
@@ -18,6 +18,7 @@ internal class KotlinConventionPlugin : Plugin<Project> {
             with(plugins) {
                 apply("kotlin")
                 apply("mpeix.aar2jar")
+                apply("mpeix.detekt")
             }
             tasks.withType<Test> {
                 useJUnitPlatform()

--- a/build-logic/src/main/kotlin/mpeix/plugins/support/DetektPlugin.kt
+++ b/build-logic/src/main/kotlin/mpeix/plugins/support/DetektPlugin.kt
@@ -1,0 +1,60 @@
+package mpeix.plugins.support
+
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import mpeix.plugins.ext.requiredVersion
+import mpeix.plugins.ext.versionCatalog
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.withType
+
+/**
+ * # Detekt Plugin
+ *
+ * A simple plugin that configures detekt in each subproject in which it is applied
+ */
+@Suppress("unused")
+class DetektPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        with(target) {
+            val libs = versionCatalog
+
+            with(plugins) {
+                val detektPluginProvider = libs.findPlugin("detekt").get()
+                apply(detektPluginProvider.get().pluginId)
+            }
+
+            detekt {
+                config = rootProject.files("detekt.yaml")
+                parallel = true
+            }
+
+            tasks.withType<Detekt> {
+                with(reports) {
+                    xml.required.set(false)
+                    html.required.set(true)
+                    txt.required.set(false)
+                    sarif.required.set(false)
+                    md.required.set(false)
+                }
+            }
+
+            dependencies {
+                val version = libs.requiredVersion("detekt")
+                detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$version")
+            }
+        }
+    }
+
+    private fun DependencyHandler.detektPlugins(notation: Any): Dependency? =
+        add("detektPlugins", notation)
+
+    private fun Project.detekt(closure: DetektExtension.() -> Unit) {
+        closure.invoke(extensions.getByType())
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,27 +13,10 @@ plugins {
     alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.gradle.android.cacheFix) apply false
     alias(libs.plugins.ksp) apply false
-    alias(libs.plugins.detekt)
+    alias(libs.plugins.detekt) apply false
 
     id("mpeix.android-jar-finder")
     id("mpeix.android") apply false
     id("mpeix.kotlin") apply false
     id("mpeix.ksp") apply false
-}
-
-// TODO: https://github.com/tonykolomeytsev/mpeiapp/issues/179
-// subprojects block prevents configure-on-demand gradle feature from working
-subprojects {
-    apply {
-        plugin("io.gitlab.arturbosch.detekt")
-    }
-    detekt {
-        config = rootProject.files("detekt.yaml")
-    }
-    dependencies {
-        detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:${detekt.toolVersion}")
-    }
-    tasks.withType<Delete> {
-        delete(rootProject.buildDir)
-    }
 }

--- a/detekt.yaml
+++ b/detekt.yaml
@@ -64,7 +64,7 @@ complexity:
     threshold: 10
     includeStaticDeclarations: false
     includePrivateDeclarations: false
-  ComplexMethod:
+  CyclomaticComplexMethod:
     active: true
     threshold: 15
     excludes: ['**/*Reducer.kt', '**/*Converter.kt']
@@ -378,8 +378,6 @@ potential-bugs:
       - 'java.util.HashSet'
       - 'java.util.LinkedHashMap'
       - 'java.util.HashMap'
-  DuplicateCaseInWhenExpression:
-    active: true
   ElseCaseInsteadOfExhaustiveWhen:
     active: false
   EqualsAlwaysReturnsTrueOrFalse:
@@ -394,7 +392,7 @@ potential-bugs:
     active: true
   IgnoredReturnValue:
     active: true
-    restrictToAnnotatedMethods: true
+    restrictToConfig: true
     returnValueAnnotations:
       - '*.CheckResult'
       - '*.CheckReturnValue'
@@ -421,15 +419,10 @@ potential-bugs:
   MissingPackageDeclaration:
     active: true
     excludes: ['**/*.kts']
-  MissingWhenCase:
-    active: true
-    allowElseExpression: true
   NullCheckOnMutableProperty:
     active: false
   NullableToStringCall:
     active: false
-  RedundantElseInWhen:
-    active: true
   UnconditionalJumpStatementInLoop:
     active: false
   UnnecessaryNotNullOperator:
@@ -491,17 +484,6 @@ style:
     active: false
     imports: []
     forbiddenPatterns: ''
-  ForbiddenMethodCall:
-    active: false
-    methods:
-      - 'kotlin.io.print'
-      - 'kotlin.io.println'
-  ForbiddenPublicDataClass:
-    active: true
-    excludes: ['**']
-    ignorePackages:
-      - '*.internal'
-      - '*.internal.*'
   ForbiddenVoid:
     active: true
     ignoreOverridden: false
@@ -511,12 +493,6 @@ style:
     ignoreOverridableFunction: true
     ignoreActualFunction: true
     excludedFunctions: ['']
-  LibraryCodeMustSpecifyReturnType:
-    active: true
-    excludes: ['**']
-  LibraryEntitiesShouldNotBePublic:
-    active: true
-    excludes: ['**']
   LoopWithTooManyJumpStatements:
     active: true
     maxJumpCount: 1

--- a/modules/feature/app_settings/build.gradle.kts
+++ b/modules/feature/app_settings/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("mpeix.android")
 }
 
+@Suppress("UnstableApiUsage")
 android.buildFeatures.viewBinding = true
 
 dependencies {


### PR DESCRIPTION
Closes #179

Настройка Detekt вынесена в отдельный Geradle плагин. Конструкция с `allprojects { ... }` в рутовом `build.gradle.kts` полностью выпилена и больше не мешает работе грэдловой фичи "configureOnDemand".

Deprecated настройки выпилены из detekt.yaml