### PR TITLE
Get rid of `r0adkll/sign-android-release@v1` action

### DIFF
--- a/.github/workflows/android-deploy.yaml
+++ b/.github/workflows/android-deploy.yaml
@@ -18,10 +18,13 @@ jobs:
           java-version: 17
           distribution: adopt
 
-      - name: Materialize google services
-        run: .ci/materialize.sh $GOOGLE_SERVICES modules/app/google-services.json
+      - name: Materialize sensitive info
+        run: |
+          .ci/materialize.sh $GOOGLE_SERVICES modules/app/google-services.json
+          .ci/materialize.sh $KEY_STORE_FILE keystore.jks
         env:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+          KEY_STORE_FILE: ${{ secrets.KEY_STORE_FILE }}
 
       - name: Release tests
         run: ./gradlew -Pci testReleaseUnitTest
@@ -32,15 +35,9 @@ jobs:
         run: ./gradlew -Pci :app:bundleRelease
         env:
           MAP_KEY: ${{ secrets.MAP_KEY }}
-
-      - name: Sign AAB
-        uses: r0adkll/sign-android-release@v1
-        with:
-          releaseDirectory: modules/app/build/outputs/bundle/release
-          signingKeyBase64: ${{ secrets.KEY_STORE_FILE }}
-          alias: ${{ secrets.ALIAS }}
-          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
-          keyPassword: ${{ secrets.KEY_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ALIAS }}
+          KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Create service_account.json
         run: echo '${{ secrets.SERVICE_ACCOUNT_JSON }}' > service_account.json

--- a/.github/workflows/android-release.yaml
+++ b/.github/workflows/android-release.yaml
@@ -23,10 +23,13 @@ jobs:
         with:
           cache-read-only: false
 
-      - name: Materialize google services
-        run: .ci/materialize.sh $GOOGLE_SERVICES modules/app/google-services.json
+      - name: Materialize sensitive info
+        run: |
+          .ci/materialize.sh $GOOGLE_SERVICES modules/app/google-services.json
+          .ci/materialize.sh $KEY_STORE_FILE keystore.jks
         env:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+          KEY_STORE_FILE: ${{ secrets.KEY_STORE_FILE }}
 
       - name: Release tests
         run: ./gradlew -Pci testReleaseUnitTest
@@ -37,19 +40,12 @@ jobs:
         run: ./gradlew -Pci :app:assembleRelease
         env:
           MAP_KEY: ${{ secrets.MAP_KEY }}
-
-      - name: Sign AAB
-        uses: r0adkll/sign-android-release@v1
-        id: sign_app
-        with:
-          releaseDirectory: modules/app/build/outputs/apk/release
-          signingKeyBase64: ${{ secrets.KEY_STORE_FILE }}
-          alias: ${{ secrets.ALIAS }}
-          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
-          keyPassword: ${{ secrets.KEY_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ALIAS }}
+          KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Upload Release APK
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: App Release
-          path: ${{steps.sign_app.outputs.signedReleaseFile}}
+          path: modules/app/build/outputs/apk/release/app-release.apk

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -19,53 +19,59 @@ dependencies {
 }
 
 gradlePlugin {
-    plugins.create("mpeixBaseAndroidModulePlugin") {
+    plugins.create("AndroidBaseConventionPlugin") {
         id = "mpeix.android.base"
         displayName = "MpeiX Android Base Plugin"
         description = "Gradle Plugin for setting up any android module"
-        implementationClass = "mpeix.plugins.convention.BaseAndroidConventionPlugin"
+        implementationClass = "mpeix.plugins.AndroidBaseConventionPlugin"
     }
-    plugins.create("mpeixAndroidModulePlugin") {
-        id = "mpeix.android"
+    plugins.create("AndroidSigningConventionPlugin") {
+        id = "mpeix.android.signing"
+        displayName = "MpeiX Android Signing Plugin"
+        description = "Gradle Plugin for signing release APK and AAB"
+        implementationClass = "mpeix.plugins.AndroidSigningConventionPlugin"
+    }
+    plugins.create("AndroidLibConventionPlugin") {
+        id = "mpeix.android.lib"
         displayName = "MpeiX Android Library Plugin"
         description = "Gradle Plugin for setting up android library module"
-        implementationClass = "mpeix.plugins.convention.AndroidLibraryConventionPlugin"
+        implementationClass = "mpeix.plugins.AndroidLibConventionPlugin"
     }
-    plugins.create("mpeixComposeAndroidModulePlugin") {
+    plugins.create("AndroidComposeConventionPlugin") {
         id = "mpeix.android.compose"
         displayName = "MpeiX Compose Android Library Plugin"
         description =
             "Gradle Plugin for setting up android library module with Compose dependencies"
-        implementationClass = "mpeix.plugins.convention.ComposeAndroidConventionPlugin"
+        implementationClass = "mpeix.plugins.AndroidComposeConventionPlugin"
     }
-    plugins.create("mpeixKotlinModulePlugin") {
-        id = "mpeix.kotlin"
+    plugins.create("KotlinLibConventionPlugin") {
+        id = "mpeix.kotlin.lib"
         displayName = "Mpeix Kotlin Plugin"
         description = "Gradle Plugin for setting up pure kotlin library module"
-        implementationClass = "mpeix.plugins.convention.KotlinConventionPlugin"
+        implementationClass = "mpeix.plugins.KotlinLibConventionPlugin"
     }
-    plugins.create("mpeixAndroidJarFinderPlugin") {
+    plugins.create("KotlinAar2JarConventionPlugin") {
+        id = "mpeix.kotlin.aar2jar"
+        displayName = "Aar2Jar Plugin"
+        description = "The Gradle Plugin that transforms AAR dependencies to JAR"
+        implementationClass = "mpeix.plugins.KotlinAar2JarConventionPlugin"
+    }
+    plugins.create("AndroidJarFinderConventionPlugin") {
         id = "mpeix.android-jar-finder"
         displayName = "Android Jar Finder Plugin"
         description = "The Gradle Plugin that finds android.jar in project environment"
-        implementationClass = "mpeix.plugins.support.AndroidJarFinderPlugin"
+        implementationClass = "mpeix.plugins.AndroidJarFinderConventionPlugin"
     }
-    plugins.create("mpeixAar2JarPlugin") {
-        id = "mpeix.aar2jar"
-        displayName = "Aar2Jar Plugin"
-        description = "The Gradle Plugin that transforms AAR dependencies to JAR"
-        implementationClass = "mpeix.plugins.support.Aar2JarPlugin"
-    }
-    plugins.create("mpeixKspSupportPlugin") {
+    plugins.create("KspConventionPlugin") {
         id = "mpeix.ksp"
         displayName = "Kotlin Symbol Processing Support Plugin"
         description = "The Gradle Plugin that adds KSP support to the module"
-        implementationClass = "mpeix.plugins.support.KspSupportPlugin"
+        implementationClass = "mpeix.plugins.KspConventionPlugin"
     }
-    plugins.create("mpeixDetektPlugin") {
+    plugins.create("DetektConventionPlugin") {
         id = "mpeix.detekt"
         displayName = "Detekt configuration Plugin"
         description = "The Gradle Plugin that configures Detekt in subproject"
-        implementationClass = "mpeix.plugins.support.DetektPlugin"
+        implementationClass = "mpeix.plugins.DetektConventionPlugin"
     }
 }

--- a/build-logic/src/main/kotlin/mpeix/plugins/AndroidBaseConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/mpeix/plugins/AndroidBaseConventionPlugin.kt
@@ -1,4 +1,4 @@
-package mpeix.plugins.convention
+package mpeix.plugins
 
 import com.android.build.gradle.BaseExtension
 import mpeix.plugins.ext.coreLibraryDesugaring
@@ -15,7 +15,7 @@ import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 @Suppress("unused")
-internal class BaseAndroidConventionPlugin : Plugin<Project> {
+internal class AndroidBaseConventionPlugin : Plugin<Project> {
 
     private val jvmTarget = JavaVersion.VERSION_11
 

--- a/build-logic/src/main/kotlin/mpeix/plugins/AndroidComposeConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/mpeix/plugins/AndroidComposeConventionPlugin.kt
@@ -1,4 +1,4 @@
-package mpeix.plugins.convention
+package mpeix.plugins
 
 import com.android.build.gradle.BaseExtension
 import mpeix.plugins.ext.debugImplementation
@@ -11,7 +11,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 
 @Suppress("unused")
-internal class ComposeAndroidConventionPlugin : Plugin<Project> {
+internal class AndroidComposeConventionPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         with(target) {

--- a/build-logic/src/main/kotlin/mpeix/plugins/AndroidJarFinderConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/mpeix/plugins/AndroidJarFinderConventionPlugin.kt
@@ -1,4 +1,4 @@
-package mpeix.plugins.support
+package mpeix.plugins
 
 import AndroidJarLocationKey
 import mpeix.plugins.ext.requiredVersion
@@ -39,7 +39,7 @@ import java.util.Properties
  * ```
  */
 @Suppress("unused")
-class AndroidJarFinderPlugin : Plugin<Project> {
+class AndroidJarFinderConventionPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         with(target) {

--- a/build-logic/src/main/kotlin/mpeix/plugins/AndroidLibConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/mpeix/plugins/AndroidLibConventionPlugin.kt
@@ -1,4 +1,4 @@
-package mpeix.plugins.convention
+package mpeix.plugins
 
 import com.android.build.gradle.LibraryExtension
 import org.gradle.api.Plugin
@@ -6,7 +6,7 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 
 @Suppress("unused")
-internal class AndroidLibraryConventionPlugin : Plugin<Project> {
+internal class AndroidLibConventionPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         with(target) {

--- a/build-logic/src/main/kotlin/mpeix/plugins/AndroidSigningConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/mpeix/plugins/AndroidSigningConventionPlugin.kt
@@ -1,0 +1,34 @@
+package mpeix.plugins
+
+import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import com.android.build.gradle.internal.dsl.SigningConfig
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.getByType
+
+@Suppress("unused")
+internal class AndroidSigningConventionPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        with(target) {
+            with(extensions.getByType<BaseAppModuleExtension>()) {
+                with(signingConfigs.maybeCreate("release")) {
+                    if (project.hasProperty("ci")) {
+                        storeFile = rootProject.file("keystore.jks")
+                        storePassword = System.getenv("KEY_STORE_PASSWORD")
+                        keyAlias = System.getenv("KEY_ALIAS")
+                        keyPassword = System.getenv("KEY_PASSWORD")
+                    } else {
+                        initWith(signingConfigs.getByName("debug"))
+                    }
+                }
+            }
+        }
+    }
+
+    private fun NamedDomainObjectContainer<SigningConfig>.configure(
+        name: String,
+        config: SigningConfig.() -> Unit,
+    ) = named(name).configure(config)
+}

--- a/build-logic/src/main/kotlin/mpeix/plugins/DetektConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/mpeix/plugins/DetektConventionPlugin.kt
@@ -1,4 +1,4 @@
-package mpeix.plugins.support
+package mpeix.plugins
 
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
@@ -18,7 +18,7 @@ import org.gradle.kotlin.dsl.withType
  * A simple plugin that configures detekt in each subproject in which it is applied
  */
 @Suppress("unused")
-class DetektPlugin : Plugin<Project> {
+class DetektConventionPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         with(target) {

--- a/build-logic/src/main/kotlin/mpeix/plugins/KotlinAar2JarConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/mpeix/plugins/KotlinAar2JarConventionPlugin.kt
@@ -1,4 +1,4 @@
-package mpeix.plugins.support
+package mpeix.plugins
 
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.Plugin
@@ -32,7 +32,7 @@ import java.util.zip.ZipFile
  *
  * ### Usage:
  *
- * This plugin is automatically applied for all subprojects with "mpeix.kotlin" plugin.
+ * This plugin is automatically applied for all subprojects with "mpeix.kotlin.lib" plugin.
  *
  * You can use `compileOnlyAar` configuration in `dependencies` section in `build.gradle.kts` of
  * pure-kotlin subprojects:
@@ -44,7 +44,7 @@ import java.util.zip.ZipFile
  * ```
  */
 @Suppress("unused")
-class Aar2JarPlugin : Plugin<Project> {
+class KotlinAar2JarConventionPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         with(target) {

--- a/build-logic/src/main/kotlin/mpeix/plugins/KotlinLibConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/mpeix/plugins/KotlinLibConventionPlugin.kt
@@ -1,4 +1,4 @@
-package mpeix.plugins.convention
+package mpeix.plugins
 
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
@@ -9,7 +9,7 @@ import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 @Suppress("unused")
-internal class KotlinConventionPlugin : Plugin<Project> {
+internal class KotlinLibConventionPlugin : Plugin<Project> {
 
     private val jvmTarget = JavaVersion.VERSION_11
 
@@ -17,7 +17,7 @@ internal class KotlinConventionPlugin : Plugin<Project> {
         return with(target) {
             with(plugins) {
                 apply("kotlin")
-                apply("mpeix.aar2jar")
+                apply("mpeix.kotlin.aar2jar")
                 apply("mpeix.detekt")
             }
             tasks.withType<Test> {

--- a/build-logic/src/main/kotlin/mpeix/plugins/KspConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/mpeix/plugins/KspConventionPlugin.kt
@@ -1,4 +1,4 @@
-package mpeix.plugins.support
+package mpeix.plugins
 
 import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Plugin
@@ -25,7 +25,7 @@ import java.io.File
  * ```
  */
 @Suppress("unused")
-class KspSupportPlugin : Plugin<Project> {
+class KspConventionPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         with(target) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
     alias(libs.plugins.detekt) apply false
 
     id("mpeix.android-jar-finder")
-    id("mpeix.android") apply false
-    id("mpeix.kotlin") apply false
+    id("mpeix.android.lib") apply false
+    id("mpeix.kotlin.lib") apply false
     id("mpeix.ksp") apply false
 }

--- a/modules/app/build.gradle.kts
+++ b/modules/app/build.gradle.kts
@@ -3,6 +3,7 @@
 plugins {
     id("com.android.application")
     id("mpeix.android.base")
+    id("mpeix.android.signing")
     id("com.google.gms.google-services")
     id("com.google.firebase.crashlytics")
 }
@@ -18,6 +19,10 @@ android {
     }
 
     buildTypes {
+        getByName("debug") {
+            isMinifyEnabled = false
+            applicationIdSuffix = ".dev"
+        }
         getByName("release") {
             isMinifyEnabled = true
             isShrinkResources = true
@@ -25,10 +30,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-        }
-        getByName("debug") {
-            isMinifyEnabled = false
-            applicationIdSuffix = ".dev"
+            signingConfig = signingConfigs.getByName("release")
         }
         configureEach {
             resValue(

--- a/modules/common/adapter/build.gradle.kts
+++ b/modules/common/adapter/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
 dependencies {

--- a/modules/common/analytics/build.gradle.kts
+++ b/modules/common/analytics/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
 dependencies {

--- a/modules/common/android/build.gradle.kts
+++ b/modules/common/android/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
+@Suppress("UnstableApiUsage")
 android.buildFeatures.viewBinding = true
 
 dependencies {

--- a/modules/common/annotations/build.gradle.kts
+++ b/modules/common/annotations/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }

--- a/modules/common/app_database/api/build.gradle.kts
+++ b/modules/common/app_database/api/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/common/app_database/impl/build.gradle.kts
+++ b/modules/common/app_database/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
     id("mpeix.ksp")
 }
 

--- a/modules/common/compose/theme/build.gradle.kts
+++ b/modules/common/compose/theme/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
     id("mpeix.android.compose")
 }
 

--- a/modules/common/coroutines/api/build.gradle.kts
+++ b/modules/common/coroutines/api/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/common/coroutines/impl/build.gradle.kts
+++ b/modules/common/coroutines/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/common/di/build.gradle.kts
+++ b/modules/common/di/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/common/elm/build.gradle.kts
+++ b/modules/common/elm/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
 dependencies {

--- a/modules/common/emoji/build.gradle.kts
+++ b/modules/common/emoji/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
 dependencies {

--- a/modules/common/feature_toggles/build.gradle.kts
+++ b/modules/common/feature_toggles/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/common/kotlin/build.gradle.kts
+++ b/modules/common/kotlin/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/common/navigation/build.gradle.kts
+++ b/modules/common/navigation/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
 dependencies {

--- a/modules/common/network/build.gradle.kts
+++ b/modules/common/network/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/common/persistent_cache/api/build.gradle.kts
+++ b/modules/common/persistent_cache/api/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/common/persistent_cache/impl/build.gradle.kts
+++ b/modules/common/persistent_cache/impl/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/common/schedule/build.gradle.kts
+++ b/modules/common/schedule/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
+@Suppress("UnstableApiUsage")
 android.buildFeatures.viewBinding = true
 
 dependencies {

--- a/modules/common/shared_preferences/build.gradle.kts
+++ b/modules/common/shared_preferences/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/coreui/build.gradle.kts
+++ b/modules/coreui/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
+@Suppress("UnstableApiUsage")
 android.buildFeatures.viewBinding = true
 
 dependencies {

--- a/modules/domain/analytics/build.gradle.kts
+++ b/modules/domain/analytics/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }

--- a/modules/domain/app_settings/build.gradle.kts
+++ b/modules/domain/app_settings/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/domain/app_settings_models/build.gradle.kts
+++ b/modules/domain/app_settings_models/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }

--- a/modules/domain/bars/build.gradle.kts
+++ b/modules/domain/bars/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/domain/dashboard/build.gradle.kts
+++ b/modules/domain/dashboard/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/domain/favorite_schedule/build.gradle.kts
+++ b/modules/domain/favorite_schedule/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
     id("mpeix.ksp")
 }
 

--- a/modules/domain/force_update/build.gradle.kts
+++ b/modules/domain/force_update/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }

--- a/modules/domain/github/build.gradle.kts
+++ b/modules/domain/github/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/domain/main_screen/build.gradle.kts
+++ b/modules/domain/main_screen/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }

--- a/modules/domain/map/build.gradle.kts
+++ b/modules/domain/map/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/domain/notes/build.gradle.kts
+++ b/modules/domain/notes/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
     id("mpeix.ksp")
 }
 

--- a/modules/domain/onboarding/build.gradle.kts
+++ b/modules/domain/onboarding/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }

--- a/modules/domain/schedule/build.gradle.kts
+++ b/modules/domain/schedule/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/domain/schedule_models/build.gradle.kts
+++ b/modules/domain/schedule_models/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }
 
 dependencies {

--- a/modules/domain/search/build.gradle.kts
+++ b/modules/domain/search/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    id("mpeix.kotlin")
+    id("mpeix.kotlin.lib")
 }

--- a/modules/feature/app_settings/build.gradle.kts
+++ b/modules/feature/app_settings/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
 @Suppress("UnstableApiUsage")

--- a/modules/feature/bars/build.gradle.kts
+++ b/modules/feature/bars/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
+@Suppress("UnstableApiUsage")
 android.buildFeatures.viewBinding = true
 
 dependencies {

--- a/modules/feature/dashboard/build.gradle.kts
+++ b/modules/feature/dashboard/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
+@Suppress("UnstableApiUsage")
 android.buildFeatures.viewBinding = true
 
 dependencies {

--- a/modules/feature/force_update/build.gradle.kts
+++ b/modules/feature/force_update/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
+@Suppress("UnstableApiUsage")
 android.buildFeatures.viewBinding = true
 
 dependencies {

--- a/modules/feature/map/build.gradle.kts
+++ b/modules/feature/map/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
 @Suppress("UnstableApiUsage")

--- a/modules/feature/notes/build.gradle.kts
+++ b/modules/feature/notes/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
+@Suppress("UnstableApiUsage")
 android.buildFeatures.viewBinding = true
 
 dependencies {

--- a/modules/feature/onboarding/build.gradle.kts
+++ b/modules/feature/onboarding/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
+@Suppress("UnstableApiUsage")
 android.buildFeatures.viewBinding = true
 
 dependencies {

--- a/modules/feature/schedule/build.gradle.kts
+++ b/modules/feature/schedule/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
+@Suppress("UnstableApiUsage")
 android.buildFeatures.viewBinding = true
 
 dependencies {

--- a/modules/feature/search/build.gradle.kts
+++ b/modules/feature/search/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
+@Suppress("UnstableApiUsage")
 android.buildFeatures.viewBinding = true
 
 dependencies {

--- a/modules/mock_server/build.gradle.kts
+++ b/modules/mock_server/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }
 
 dependencies {

--- a/modules/resources/icons/build.gradle.kts
+++ b/modules/resources/icons/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }

--- a/modules/resources/images/build.gradle.kts
+++ b/modules/resources/images/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }

--- a/modules/resources/strings/build.gradle.kts
+++ b/modules/resources/strings/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    id("mpeix.android")
+    id("mpeix.android.lib")
 }


### PR DESCRIPTION
Closes #222 

- Sign app with standard signingConfigs feature of android gradle plugin
- Remove deprecated actions from release and deploy workflows
- Refactor convention plugins structure
- Add signing convention plugin