### PR TITLE
Compose ELM support

### DIFF
--- a/build-logic/src/main/kotlin/mpeix/plugins/AndroidComposeConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/mpeix/plugins/AndroidComposeConventionPlugin.kt
@@ -11,6 +11,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.io.File
 
 @Suppress("unused")
 internal class AndroidComposeConventionPlugin : Plugin<Project> {
@@ -29,14 +30,14 @@ internal class AndroidComposeConventionPlugin : Plugin<Project> {
                 }
             }
 
-            tasks.withType<KotlinCompile>() {
+            tasks.withType<KotlinCompile> {
                 kotlinOptions {
-                    freeCompilerArgs = freeCompilerArgs + listOf(
-                        "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-                        "-opt-in=androidx.compose.foundation.layout.ExperimentalLayoutApi",
-                        "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi",
-                        "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi",
-                    )
+                    val composeMetricsDir = buildDir.resolve("compose-metrics")
+                    val composeReportsDir = buildDir.resolve("compose-reports")
+                    freeCompilerArgs = freeCompilerArgs +
+                            getOptInExperimentalApiCompilerArgs() +
+                            getComposeCompilerMetricsCompilerArgs(composeMetricsDir) +
+                            getComposeCompilerReportsCompilerArgs(composeReportsDir)
                 }
             }
 
@@ -48,4 +49,24 @@ internal class AndroidComposeConventionPlugin : Plugin<Project> {
             }
         }
     }
+
+    private fun getOptInExperimentalApiCompilerArgs(): List<String> =
+        listOf(
+            "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
+            "-opt-in=androidx.compose.foundation.layout.ExperimentalLayoutApi",
+            "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi",
+            "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi",
+        )
+
+    private fun getComposeCompilerMetricsCompilerArgs(outputDir: File): List<String> =
+        listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$outputDir",
+        )
+
+    private fun getComposeCompilerReportsCompilerArgs(outputDir: File): List<String> =
+        listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$outputDir"
+        )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -97,6 +97,7 @@ appyx-core = { module = "com.bumble.appyx:core", version.ref = "appyx" }
 # Koin Libraries
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+koin-compose = { module = "io.insert-koin:koin-androidx-compose", version = "3.4.5" }
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 
 # Firebase Libraries

--- a/modules/app_ui_kit/build.gradle.kts
+++ b/modules/app_ui_kit/build.gradle.kts
@@ -31,7 +31,13 @@ dependencies {
     implementation(project(":ui_kit_topappbar"))
     implementation(project(":common_navigation_api"))
     implementation(project(":common_navigation_compose"))
+    implementation(project(":common_elm"))
+    implementation(project(":common_kotlin"))
 
     implementation(libs.compose.activity)
     implementation(libs.appyx.core)
+    implementation(libs.vivid.elmslie.core)
+    implementation(libs.vivid.elmslie.coroutines)
+    implementation(libs.koin.core)
+    implementation(libs.koin.android)
 }

--- a/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/MainActivity.kt
+++ b/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/MainActivity.kt
@@ -8,12 +8,17 @@ import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
 import com.bumble.appyx.core.integration.NodeHost
 import com.bumble.appyx.core.integrationpoint.NodeComponentActivity
+import kekmech.ru.mpeiapp.demo.di.AppModule
 import kekmech.ru.ui_theme.theme.MpeixTheme
+import org.koin.core.context.startKoin
 
 class MainActivity : NodeComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        startKoin {
+            modules(AppModule)
+        }
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             MpeixTheme {

--- a/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/di/AppModule.kt
+++ b/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/di/AppModule.kt
@@ -1,0 +1,8 @@
+package kekmech.ru.mpeiapp.demo.di
+
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoStoreFactory
+import org.koin.dsl.module
+
+val AppModule = module {
+    factory { ElmDemoStoreFactory() }
+}

--- a/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/ElmDemoScreen.kt
+++ b/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/ElmDemoScreen.kt
@@ -15,9 +15,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
+import kekmech.ru.common_elm.Resource
 import kekmech.ru.common_elm.elmNode
 import kekmech.ru.common_elm.rememberAcceptAction
-import kekmech.ru.common_kotlin.Resource
 import kekmech.ru.common_navigation_api.NavTarget
 import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoStore
 import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoStoreFactory

--- a/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/ElmDemoScreen.kt
+++ b/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/ElmDemoScreen.kt
@@ -32,10 +32,11 @@ internal class ElmDemoScreenNavTarget(
 ) : NavTarget {
 
     override fun resolve(buildContext: BuildContext): Node =
-        elmNode<ElmDemoStoreFactory, _, _, _>(
+        elmNode(
             buildContext = buildContext,
+            storeFactoryClass = ElmDemoStoreFactory::class,
             factory = { create(randomArgument = randomArgument) },
-        ) { _, store, state -> ElmDemoScreen(store = store, state = state) }
+        ) { store, state, _ -> ElmDemoScreen(store = store, state = state) }
 }
 
 @Composable

--- a/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/ElmDemoScreen.kt
+++ b/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/ElmDemoScreen.kt
@@ -1,0 +1,76 @@
+package kekmech.ru.mpeiapp.demo.screens.elmslie
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.node.Node
+import kekmech.ru.common_elm.ElmNavTarget
+import kekmech.ru.common_elm.rememberAcceptAction
+import kekmech.ru.common_kotlin.Resource
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoStore
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoStoreFactory
+import kekmech.ru.ui_kit_topappbar.TopAppBar
+import kotlinx.parcelize.Parcelize
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoEffect as Effect
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoEvent as Event
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoState as ElmState
+
+@Parcelize
+internal class ElmDemoScreenNavTarget(
+    private val randomArgument: Int,
+) : ElmNavTarget<Event, Effect, ElmState>() {
+
+    override fun resolve(buildContext: BuildContext): Node =
+        elmNode<ElmDemoStoreFactory>(
+            buildContext = buildContext,
+            factory = { create(randomArgument = randomArgument) },
+        ) { _, store, state -> ElmDemoScreen(store = store, state = state) }
+}
+
+@Composable
+private fun ElmDemoScreen(
+    store: ElmDemoStore,
+    state: ElmState,
+) {
+    val accept = store.rememberAcceptAction()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = "Elm Demo")
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(text = "Random argument = ${state.randomArgument}")
+            Spacer(modifier = Modifier.height(16.dp))
+            val loadedResource = when (state.resource) {
+                is Resource.Loading -> "Loading..."
+                is Resource.Data -> state.resource.value
+                is Resource.Error -> "Error: ${state.resource.error}"
+            }
+            Text(text = "Loaded resource = $loadedResource")
+            Spacer(modifier = Modifier.height(16.dp))
+            TextButton(
+                onClick = { accept(Event.Ui.Click.TextButton) },
+            ) {
+                Text(text = "Load new resource")
+            }
+        }
+    }
+}

--- a/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/ElmDemoScreen.kt
+++ b/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/ElmDemoScreen.kt
@@ -15,24 +15,24 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
-import kekmech.ru.common_elm.ElmNavTarget
+import kekmech.ru.common_elm.elmNode
 import kekmech.ru.common_elm.rememberAcceptAction
 import kekmech.ru.common_kotlin.Resource
+import kekmech.ru.common_navigation_api.NavTarget
 import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoStore
 import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoStoreFactory
 import kekmech.ru.ui_kit_topappbar.TopAppBar
 import kotlinx.parcelize.Parcelize
-import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoEffect as Effect
 import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoEvent as Event
 import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoState as ElmState
 
 @Parcelize
 internal class ElmDemoScreenNavTarget(
     private val randomArgument: Int,
-) : ElmNavTarget<Event, Effect, ElmState>() {
+) : NavTarget {
 
     override fun resolve(buildContext: BuildContext): Node =
-        elmNode<ElmDemoStoreFactory>(
+        elmNode<ElmDemoStoreFactory, _, _, _>(
             buildContext = buildContext,
             factory = { create(randomArgument = randomArgument) },
         ) { _, store, state -> ElmDemoScreen(store = store, state = state) }

--- a/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/elm/ElmDemoActor.kt
+++ b/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/elm/ElmDemoActor.kt
@@ -1,0 +1,29 @@
+package kekmech.ru.mpeiapp.demo.screens.elmslie.elm
+
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoCommand
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoEvent
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoEvent.Internal
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import vivid.money.elmslie.coroutines.Actor
+import java.util.UUID
+import kotlin.random.Random
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoCommand as Command
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoEvent as Event
+
+internal class ElmDemoActor : Actor<Command, Event> {
+
+    override fun execute(command: ElmDemoCommand): Flow<ElmDemoEvent> =
+        when (command) {
+            is ElmDemoCommand.LoadNewResource -> flow {
+                @Suppress("MagicNumber")
+                delay(1000L)
+                if (Random.nextBoolean()) {
+                    emit(UUID.randomUUID().toString())
+                } else {
+                    throw IllegalStateException("Oh no!")
+                }
+            }.mapEvents(Internal::LoadNewResourceSuccess, Internal::LoadNewResourceFailure)
+        }
+}

--- a/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/elm/ElmDemoModels.kt
+++ b/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/elm/ElmDemoModels.kt
@@ -1,6 +1,6 @@
 package kekmech.ru.mpeiapp.demo.screens.elmslie.elm
 
-import kekmech.ru.common_kotlin.Resource
+import kekmech.ru.common_elm.Resource
 import vivid.money.elmslie.core.store.Store
 
 typealias ElmDemoStore = Store<ElmDemoEvent, ElmDemoEffect, ElmDemoState>

--- a/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/elm/ElmDemoModels.kt
+++ b/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/elm/ElmDemoModels.kt
@@ -1,0 +1,37 @@
+package kekmech.ru.mpeiapp.demo.screens.elmslie.elm
+
+import kekmech.ru.common_kotlin.Resource
+import vivid.money.elmslie.core.store.Store
+
+typealias ElmDemoStore = Store<ElmDemoEvent, ElmDemoEffect, ElmDemoState>
+
+data class ElmDemoState(
+    val randomArgument: Int,
+    val resource: Resource<String> = Resource.Loading,
+)
+
+sealed interface ElmDemoEvent {
+
+    sealed interface Ui : ElmDemoEvent {
+
+        object Init : Ui
+
+        sealed interface Click : Ui {
+
+            object TextButton : Click
+        }
+    }
+
+    sealed interface Internal : ElmDemoEvent {
+
+        data class LoadNewResourceSuccess(val string: String) : Internal
+        data class LoadNewResourceFailure(val error: Throwable) : Internal
+    }
+}
+
+sealed interface ElmDemoCommand {
+
+    object LoadNewResource : ElmDemoCommand
+}
+
+sealed interface ElmDemoEffect

--- a/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/elm/ElmDemoReducer.kt
+++ b/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/elm/ElmDemoReducer.kt
@@ -1,6 +1,6 @@
 package kekmech.ru.mpeiapp.demo.screens.elmslie.elm
 
-import kekmech.ru.common_kotlin.Resource
+import kekmech.ru.common_elm.Resource
 import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoEvent.Internal
 import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoEvent.Ui
 import vivid.money.elmslie.core.store.dsl_reducer.ScreenDslReducer

--- a/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/elm/ElmDemoReducer.kt
+++ b/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/elm/ElmDemoReducer.kt
@@ -1,0 +1,36 @@
+package kekmech.ru.mpeiapp.demo.screens.elmslie.elm
+
+import kekmech.ru.common_kotlin.Resource
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoEvent.Internal
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoEvent.Ui
+import vivid.money.elmslie.core.store.dsl_reducer.ScreenDslReducer
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoCommand as Command
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoEffect as Effect
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoEvent as Event
+import kekmech.ru.mpeiapp.demo.screens.elmslie.elm.ElmDemoState as State
+
+internal class ElmDemoReducer :
+    ScreenDslReducer<Event, Ui, Internal, State, Effect, Command>(
+        uiEventClass = Ui::class,
+        internalEventClass = Internal::class,
+    ) {
+
+    override fun Result.internal(event: Internal) =
+        when (event) {
+            is Internal.LoadNewResourceSuccess ->
+                state { copy(resource = Resource.Data(event.string)) }
+            is Internal.LoadNewResourceFailure ->
+                state { copy(resource = Resource.Error(event.error)) }
+        }
+
+    override fun Result.ui(event: Ui) =
+        when (event) {
+            is Ui.Init -> {
+                commands { +Command.LoadNewResource }
+            }
+            is Ui.Click.TextButton -> {
+                state { copy(resource = Resource.Loading) }
+                commands { +Command.LoadNewResource }
+            }
+        }
+}

--- a/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/elm/ElmDemoStoreFactory.kt
+++ b/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/elmslie/elm/ElmDemoStoreFactory.kt
@@ -1,0 +1,14 @@
+package kekmech.ru.mpeiapp.demo.screens.elmslie.elm
+
+import vivid.money.elmslie.coroutines.ElmStoreCompat
+
+internal class ElmDemoStoreFactory {
+
+    fun create(randomArgument: Int): ElmDemoStore =
+        ElmStoreCompat(
+            initialState = ElmDemoState(randomArgument = randomArgument),
+            reducer = ElmDemoReducer(),
+            actor = ElmDemoActor(),
+            startEvent = ElmDemoEvent.Ui.Init,
+        )
+}

--- a/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/main/MainScreen.kt
+++ b/modules/app_ui_kit/src/main/kotlin/kekmech/ru/mpeiapp/demo/screens/main/MainScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
@@ -17,10 +18,12 @@ import kekmech.ru.common_navigation_api.NavTarget
 import kekmech.ru.common_navigation_compose.LocalBackStackNavigator
 import kekmech.ru.mpeiapp.demo.screens.colors.ColorsScreenNavTarget
 import kekmech.ru.mpeiapp.demo.screens.components.ComponentsScreenNavTarget
+import kekmech.ru.mpeiapp.demo.screens.elmslie.ElmDemoScreenNavTarget
 import kekmech.ru.mpeiapp.demo.screens.typography.TypographyScreenNavTarget
 import kekmech.ru.mpeiapp.demo.ui.SectionItem
 import kekmech.ru.ui_kit_topappbar.TopAppBar
 import kotlinx.parcelize.Parcelize
+import kotlin.random.Random
 
 @Parcelize
 internal class MainScreenNavTarget(private val greetings: String = "MpeiX UI-Kit") : NavTarget {
@@ -73,6 +76,16 @@ private fun MainScreen(greetings: String) {
                         navigator.navigate(ComponentsScreenNavTarget())
                     },
                     name = "Components",
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            item("elmslie") {
+                val randomArgument = remember { Random.nextInt() }
+                SectionItem(
+                    onClick = {
+                        navigator.navigate(ElmDemoScreenNavTarget(randomArgument = randomArgument))
+                    },
+                    name = "ELM Demo (arg = $randomArgument)",
                     modifier = Modifier.fillMaxWidth()
                 )
             }

--- a/modules/common/elm/build.gradle.kts
+++ b/modules/common/elm/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("mpeix.android.lib")
+    id("mpeix.android.compose")
 }
 
 dependencies {
@@ -7,6 +8,7 @@ dependencies {
     implementation(libs.androidx.coreKtx)
     implementation(libs.androidx.lifecycleExtensions)
     implementation(libs.google.material)
+    implementation(libs.koin.compose)
 
     implementation(libs.rx.java)
     implementation(libs.vivid.elmslie.android)

--- a/modules/common/elm/build.gradle.kts
+++ b/modules/common/elm/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     implementation(libs.androidx.appCompat)
     implementation(libs.androidx.coreKtx)
     implementation(libs.androidx.lifecycleExtensions)
+    implementation(libs.appyx.core)
     implementation(libs.google.material)
     implementation(libs.koin.compose)
 
@@ -15,4 +16,5 @@ dependencies {
     implementation(libs.vivid.elmslie.core)
 
     implementation(project(":common_android"))
+    implementation(project(":common_navigation_api"))
 }

--- a/modules/common/elm/src/main/kotlin/kekmech/ru/common_elm/ElmNavTarget.kt
+++ b/modules/common/elm/src/main/kotlin/kekmech/ru/common_elm/ElmNavTarget.kt
@@ -1,12 +1,14 @@
 package kekmech.ru.common_elm
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.node
 import vivid.money.elmslie.core.store.Store
+import kotlin.reflect.KClass
 
 /**
  * Extension for creating Appyx nodes with ELM Store.
@@ -20,23 +22,29 @@ import vivid.money.elmslie.core.store.Store
  * ) : NavTarget {
  *
  *     override fun resolve(buildContext: BuildContext): Node =
- *         elmNode<ElmDemoStoreFactory, _, _, _>(
+ *         elmNode(
  *             buildContext = buildContext,
+ *             storeFactoryClass = MyStoreFactory::class,
  *             factory = { create(myArg = myArg) },
- *         ) { _, store, state -> MyScreen(store = store, state = state) }
+ *         ) { store, state, modifier -> MyScreen(store, state, modifier) }
  * }
  * ```
  *
  * @see com.bumble.appyx.core.node.node
  * @see com.bumble.appyx.core.node.Node
  */
-inline fun <reified Factory : Any, Event : Any, Effect : Any, State : Any> elmNode(
+inline fun <StoreFactory : Any, Event : Any, Effect : Any, State : Any> elmNode(
     buildContext: BuildContext,
-    crossinline factory: Factory.() -> Store<Event, Effect, State>,
-    crossinline composable: @Composable (Modifier, Store<Event, Effect, State>, State) -> Unit,
+    storeFactoryClass: KClass<StoreFactory>,
+    crossinline factory: StoreFactory.() -> Store<Event, Effect, State>,
+    crossinline composable: @Composable (
+        store: Store<Event, Effect, State>,
+        state: State,
+        modifier: Modifier,
+    ) -> Unit,
 ): Node =
-    node(buildContext) {
-        val store = rememberElmStore(factory)
-        val state by store.asState()
-        composable.invoke(it, store, state)
+    node(buildContext) { modifier ->
+        val store = rememberElmStore(storeFactoryClass, factory)
+        val state by store.states().collectAsState(initial = store.currentState)
+        composable.invoke(store, state, modifier)
     }

--- a/modules/common/elm/src/main/kotlin/kekmech/ru/common_elm/ElmNavTarget.kt
+++ b/modules/common/elm/src/main/kotlin/kekmech/ru/common_elm/ElmNavTarget.kt
@@ -1,0 +1,25 @@
+package kekmech.ru.common_elm
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.node.Node
+import com.bumble.appyx.core.node.node
+import kekmech.ru.common_navigation_api.NavTarget
+import vivid.money.elmslie.core.store.Store
+
+abstract class ElmNavTarget<Event : Any, Effect : Any, State : Any> : NavTarget {
+
+    inline fun <reified Factory : Any> elmNode(
+        buildContext: BuildContext,
+        crossinline factory: Factory.() -> Store<Event, Effect, State>,
+        crossinline composable: @Composable (Modifier, Store<Event, Effect, State>, State) -> Unit,
+    ): Node =
+        node(buildContext) {
+            val store = rememberElmStore(factory)
+            val state by store.asState()
+            composable.invoke(it, store, state)
+        }
+}
+

--- a/modules/common/elm/src/main/kotlin/kekmech/ru/common_elm/ElmNavTarget.kt
+++ b/modules/common/elm/src/main/kotlin/kekmech/ru/common_elm/ElmNavTarget.kt
@@ -6,20 +6,37 @@ import androidx.compose.ui.Modifier
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.node
-import kekmech.ru.common_navigation_api.NavTarget
 import vivid.money.elmslie.core.store.Store
 
-abstract class ElmNavTarget<Event : Any, Effect : Any, State : Any> : NavTarget {
-
-    inline fun <reified Factory : Any> elmNode(
-        buildContext: BuildContext,
-        crossinline factory: Factory.() -> Store<Event, Effect, State>,
-        crossinline composable: @Composable (Modifier, Store<Event, Effect, State>, State) -> Unit,
-    ): Node =
-        node(buildContext) {
-            val store = rememberElmStore(factory)
-            val state by store.asState()
-            composable.invoke(it, store, state)
-        }
-}
-
+/**
+ * Extension for creating Appyx nodes with ELM Store.
+ *
+ * Usage in `NavTarget`:
+ *
+ * ```kotlin
+ * @Parcelize
+ * internal class MyScreenNavTarget(
+ *     private val myArg: Int,
+ * ) : NavTarget {
+ *
+ *     override fun resolve(buildContext: BuildContext): Node =
+ *         elmNode<ElmDemoStoreFactory, _, _, _>(
+ *             buildContext = buildContext,
+ *             factory = { create(myArg = myArg) },
+ *         ) { _, store, state -> MyScreen(store = store, state = state) }
+ * }
+ * ```
+ *
+ * @see com.bumble.appyx.core.node.node
+ * @see com.bumble.appyx.core.node.Node
+ */
+inline fun <reified Factory : Any, Event : Any, Effect : Any, State : Any> elmNode(
+    buildContext: BuildContext,
+    crossinline factory: Factory.() -> Store<Event, Effect, State>,
+    crossinline composable: @Composable (Modifier, Store<Event, Effect, State>, State) -> Unit,
+): Node =
+    node(buildContext) {
+        val store = rememberElmStore(factory)
+        val state by store.asState()
+        composable.invoke(it, store, state)
+    }

--- a/modules/common/elm/src/main/kotlin/kekmech/ru/common_elm/ElmStoreAccessors.kt
+++ b/modules/common/elm/src/main/kotlin/kekmech/ru/common_elm/ElmStoreAccessors.kt
@@ -54,10 +54,10 @@ inline fun <reified Factory : Any, Event : Any, Effect : Any, State : Any> remem
  *
  * Usage:
  * ```kotlin
- * val acceptAction = store.rememberAcceptAction()
+ * val accept = store.rememberAcceptAction()
  *
  * SomeView(
- *     someCallback = { acceptAction(Ui.Some.Event) },
+ *     someCallback = { accept(Ui.Some.Event) },
  * )
  * ```
  *
@@ -74,10 +74,10 @@ interface ElmAcceptAction<Event : Any> {
  *
  * Usage:
  * ```kotlin
- * val acceptAction = store.rememberAcceptAction()
+ * val accept = store.rememberAcceptAction()
  *
  * SomeView(
- *     someCallback = { acceptAction(Ui.Some.Event) },
+ *     someCallback = { accept(Ui.Some.Event) },
  * )
  * ```
  *
@@ -97,5 +97,5 @@ inline fun <reified Event : Any> Store<Event, *, *>.rememberAcceptAction(): ElmA
  * Collect ELM state as Compose [State].
  */
 @Composable
-inline fun <reified ElmState : Any> Store<*, *, ElmState>.asState(): State<ElmState> =
+fun <ElmState : Any> Store<*, *, ElmState>.asState(): State<ElmState> =
     states().collectAsState(initial = currentState)

--- a/modules/common/elm/src/main/kotlin/kekmech/ru/common_elm/ElmStoreAccessors.kt
+++ b/modules/common/elm/src/main/kotlin/kekmech/ru/common_elm/ElmStoreAccessors.kt
@@ -1,0 +1,101 @@
+package kekmech.ru.common_elm
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import org.koin.compose.rememberKoinInject
+import vivid.money.elmslie.core.store.Store
+
+/**
+ * Inject ELM Store into any Composable screen.
+ *
+ * ## Example:
+ *
+ * Your screen's store factory:
+ * ```kotlin
+ * //
+ * internal class MyStoreFactory(
+ *     private val dependency1: DependencyType1,
+ *     private val dependency2: DependencyType2,
+ *     ...
+ * ) {
+ *
+ *     fun create(arg1: String, arg2: Long): ElmStore<...> = ...
+ * }
+ * ```
+ *
+ * Your screen's Composable:
+ * ```kotlin
+ * @Composable
+ * fun MyScreen(
+ *     arg1: String,
+ *     arg2: Long,
+ *     store: ElmStore<...> = rememberElmStore<MyStoreFactory, _, _, _> { create(arg1, arg2) },
+ * ) {
+ *     ...
+ * }
+ * ```
+ */
+@Composable
+inline fun <reified Factory : Any, Event : Any, Effect : Any, State : Any> rememberElmStore(
+    crossinline factory: Factory.() -> Store<Event, Effect, State>,
+): Store<Event, Effect, State> {
+    val storeFactoryInstance = rememberKoinInject<Factory>()
+    return remember(Factory::class) { factory.invoke(storeFactoryInstance) }
+}
+
+/**
+ * Stable accessor for [Store.accept].
+ *
+ * [Store] and the classes that implement it are unstable, and passing callbacks with them to
+ * lower-level composables will lead to unnecessary recomposition.
+ *
+ * Usage:
+ * ```kotlin
+ * val acceptAction = store.rememberAcceptAction()
+ *
+ * SomeView(
+ *     someCallback = { acceptAction(Ui.Some.Event) },
+ * )
+ * ```
+ *
+ * @see [rememberAcceptAction]
+ */
+@Stable
+interface ElmAcceptAction<Event : Any> {
+
+    operator fun invoke(event: Event)
+}
+
+/**
+ * Create stable accessor for [Store.accept].
+ *
+ * Usage:
+ * ```kotlin
+ * val acceptAction = store.rememberAcceptAction()
+ *
+ * SomeView(
+ *     someCallback = { acceptAction(Ui.Some.Event) },
+ * )
+ * ```
+ *
+ * @see [ElmAcceptAction]
+ */
+@Composable
+inline fun <reified Event : Any> Store<Event, *, *>.rememberAcceptAction(): ElmAcceptAction<Event> =
+    remember(Event::class) {
+        object : ElmAcceptAction<Event> {
+            override fun invoke(event: Event) {
+                this@rememberAcceptAction.accept(event)
+            }
+        }
+    }
+
+/**
+ * Collect ELM state as Compose [State].
+ */
+@Composable
+inline fun <reified ElmState : Any> Store<*, *, ElmState>.asState(): State<ElmState> =
+    states().collectAsState(initial = currentState)

--- a/modules/common/elm/src/main/kotlin/kekmech/ru/common_elm/ElmStoreAccessors.kt
+++ b/modules/common/elm/src/main/kotlin/kekmech/ru/common_elm/ElmStoreAccessors.kt
@@ -43,7 +43,11 @@ inline fun <reified Factory : Any, Event : Any, Effect : Any, State : Any> remem
     crossinline factory: Factory.() -> Store<Event, Effect, State>,
 ): Store<Event, Effect, State> {
     val storeFactoryInstance = rememberKoinInject<Factory>()
-    return remember(Factory::class) { factory.invoke(storeFactoryInstance) }
+    return remember(Factory::class) {
+        factory
+            .invoke(storeFactoryInstance)
+            .also { it.start() }
+    }
 }
 
 /**

--- a/modules/common/elm/src/main/kotlin/kekmech/ru/common_elm/Resource.kt
+++ b/modules/common/elm/src/main/kotlin/kekmech/ru/common_elm/Resource.kt
@@ -1,5 +1,8 @@
-package kekmech.ru.common_kotlin
+package kekmech.ru.common_elm
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 sealed class Resource<out T : Any> private constructor() {
 
     open val value: T? = null

--- a/modules/feature/dashboard/src/main/kotlin/kekmech/ru/feature_dashboard/screens/main/elm/DashboardModels.kt
+++ b/modules/feature/dashboard/src/main/kotlin/kekmech/ru/feature_dashboard/screens/main/elm/DashboardModels.kt
@@ -1,6 +1,6 @@
 package kekmech.ru.feature_dashboard.screens.main.elm
 
-import kekmech.ru.common_kotlin.Resource
+import kekmech.ru.common_elm.Resource
 import kekmech.ru.domain_dashboard.dto.UpcomingEventsPrediction
 import kekmech.ru.domain_favorite_schedule.dto.FavoriteSchedule
 import kekmech.ru.domain_notes.dto.Note

--- a/modules/feature/dashboard/src/main/kotlin/kekmech/ru/feature_dashboard/screens/main/elm/DashboardReducer.kt
+++ b/modules/feature/dashboard/src/main/kotlin/kekmech/ru/feature_dashboard/screens/main/elm/DashboardReducer.kt
@@ -1,8 +1,8 @@
 package kekmech.ru.feature_dashboard.screens.main.elm
 
-import kekmech.ru.common_kotlin.Resource
+import kekmech.ru.common_elm.Resource
+import kekmech.ru.common_elm.toResource
 import kekmech.ru.common_kotlin.moscowLocalDate
-import kekmech.ru.common_kotlin.toResource
 import kekmech.ru.domain_dashboard.dto.UpcomingEventsPrediction
 import kekmech.ru.domain_schedule.dto.SelectedSchedule
 import kekmech.ru.feature_dashboard.screens.main.elm.DashboardEvent.Internal

--- a/modules/feature/dashboard/src/main/kotlin/kekmech/ru/feature_dashboard/screens/main/upcoming_events/UpcomingEventsListConverter.kt
+++ b/modules/feature/dashboard/src/main/kotlin/kekmech/ru/feature_dashboard/screens/main/upcoming_events/UpcomingEventsListConverter.kt
@@ -1,7 +1,7 @@
 package kekmech.ru.feature_dashboard.screens.main.upcoming_events
 
 import android.content.Context
-import kekmech.ru.common_kotlin.Resource
+import kekmech.ru.common_elm.Resource
 import kekmech.ru.common_schedule.utils.withNotePreview
 import kekmech.ru.coreui.items.EmptyStateItem
 import kekmech.ru.coreui.items.ErrorStateItem

--- a/modules/feature/dashboard/src/test/kotlin/kekmech/ru/feature_dashboard/DashboardReducerTest.kt
+++ b/modules/feature/dashboard/src/test/kotlin/kekmech/ru/feature_dashboard/DashboardReducerTest.kt
@@ -7,8 +7,8 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
-import kekmech.ru.common_kotlin.Resource
-import kekmech.ru.common_kotlin.toResource
+import kekmech.ru.common_elm.Resource
+import kekmech.ru.common_elm.toResource
 import kekmech.ru.domain_dashboard.dto.UpcomingEventsPrediction
 import kekmech.ru.domain_favorite_schedule.dto.FavoriteSchedule
 import kekmech.ru.domain_notes.dto.Note


### PR DESCRIPTION
Добавил биндинги для ELM в Compose "мир" приложения и сделал демо работы экрана `ElmDemoScreen` в `:app_ui_kit`.

Если по пунктам:
- Добавил расширение `rememberElmStore`, которое просто инжектит стор. Расширение просто берет тип `*StoreFactory` и позволяет нам вызвать его `create()` метод внутри лямбды.
- Добавил расширение `Store.asState()`, которое подписывается на стейт. Нейминг можно изменить, если честно. Возможно на collectState или еще что-то.
- Добавил расширение `Store.rememberAcceptAction()` которое предоставляет "стабильную"
 с точки зрения композа ручку для вызова `store.accept()`. Иначе колбеки со стором, который не помечен как `@Stable`/`@Immutable`, будут рекомпозить экраны слишком часто.
- Добавил `elmNode`- расширение, которое позволяет писать меньше кода при создании NavTarget для экранов с ELM.
- Добавил также демо передачи аргументов в экран.